### PR TITLE
Add TypeScript definitions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-*
-!lib/**
-!.npmignore

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Configuration of the team work.
+ */
+export interface Options {
+    /**
+     * Number of meetings this team should attend before delivering work. Defaults to 1.
+     */
+    meetings?: number;
+}
+
+type ElementOf<T> = T extends (infer E)[] ? E : T;
+
+export class Teamwork<Results extends any | any[] = void> {
+    /**
+     * Start a new team work.
+     * @param options Configuration of the team work.
+     */
+    constructor(options?: Options);
+
+    /**
+     * Resulting work when all the meetings are done.
+     */
+    work: Promise<Results>;
+
+    /**
+     * Attend a single meeting.
+     * @param note An optional note that will be included in the work's results. If an error is provided, the work will be immediately rejected with that error.
+     */
+    attend(note?: Error | ElementOf<Results>): void;
+
+    /**
+     * Wait for the current work to be done and start another team work.
+     * @param options New configuration of the team work.
+     */
+    regroup(options?: Options) : Promise<void>;
+}
+
+export default Teamwork;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,27 @@
+import { expectError, expectType } from 'tsd';
+import { Teamwork } from '.';
+
+// Constructor tests
+expectType<Teamwork>(new Teamwork());
+expectType<Teamwork>(new Teamwork({ meetings: 2 }));
+expectError(new Teamwork({ foo: true }));
+expectError(new Teamwork({ meetings: 'foo' }));
+expectType<Promise<void>>(new Teamwork().work);
+expectType<void>(await new Teamwork().work);
+
+// Attend tests
+expectType<void>(new Teamwork().attend());
+expectType<void>(new Teamwork().attend(new Error()));
+expectType<void>(new Teamwork<string>().attend('foo'));
+expectType<void>(new Teamwork<string[]>().attend('foo'));
+expectError(new Teamwork<boolean>().attend('foo'));
+expectError(new Teamwork<boolean[]>().attend('foo'));
+expectType<void>(new Teamwork<[boolean, string]>().attend('foo'));
+
+// Work tests
+expectType<Promise<void>>(new Teamwork().work);
+expectType<Promise<boolean>>(new Teamwork<boolean>().work);
+expectType<Promise<boolean[]>>(new Teamwork<boolean[]>().work);
+
+// Regroup tests
+expectType<Promise<void>>(new Teamwork().regroup());

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,3 +51,15 @@ exports = module.exports = internals.Team = class {
         this._init(options);
     }
 };
+
+Object.defineProperties(internals.Team, {
+    __esModule: {
+        value: true
+    },
+    default: {
+        value: internals.Team
+    },
+    Teamwork: {
+        value: internals.Team
+    }
+});

--- a/package.json
+++ b/package.json
@@ -9,14 +9,21 @@
     "flow control",
     "callback"
   ],
+  "files": [
+    "lib",
+    "index.d.ts"
+  ],
+  "types": "index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "code": "5.x.x",
-    "lab": "17.x.x"
+    "lab": "17.x.x",
+    "tsd": "0.7.0"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",
-    "test-cov-html": "lab -a code -r html -o coverage.html"
+    "test-cov-html": "lab -a code -r html -o coverage.html",
+    "test-types": "tsd"
   },
   "license": "BSD-3-Clause"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,26 @@ const it = lab.test;
 
 describe('Team', () => {
 
+    describe('ES6 modules properties', () => {
+
+        it('the ES6 module marker is defined', () => {
+
+            expect(Teamwork.__esModule).to.be.true();
+        });
+
+        it('the default property is defined', () => {
+
+            expect(Teamwork.default).to.exist();
+            expect(Teamwork.default).to.shallow.equal(Teamwork);
+        });
+
+        it('the Teamwork property is defined', () => {
+
+            expect(Teamwork.Teamwork).to.exist();
+            expect(Teamwork.Teamwork).to.shallow.equal(Teamwork);
+        });
+    });
+
     it('resolve when meeting is attended', async () => {
 
         const team = new Teamwork();


### PR DESCRIPTION
The only part that can't really be done with TypeScript is `regroup`, as an assigned variable can't change type like that, but it's only a problem if notes are typed. Otherwise I think it's complete.