### PR TITLE
fix: Require Node.js >= 12.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "4.0.0",
   "repository": "git://github.com/hapijs/teamwork",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">= 12.4.0"
+  },
   "files": [
     "lib"
   ],


### PR DESCRIPTION
Since this project is using [private class fields](https://github.com/tc39/proposal-class-fields) (e.g. in [`index.js`](https://github.com/hapijs/teamwork/blob/fcd3a67d3d5619fafb06ec5a3c060fd92447844d/lib/index.js#L8)), it's not possible to use this project as-is with Node < 12.4.0.

This PR makes this project available only for users with Node >= 12.4.0 installed.

---

To support users with Node.js < 12.4.0, you could alternatively remove the private class fields.