### PR TITLE
Fix memory leaks on attend for infinite teamwork instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,9 +42,13 @@ exports.Team = class {
         if (this.#strict && this.#done) {
             throw new Error('Unscheduled meeting');
         }
+        else if (this.#done) {
+            return;
+        }
 
         if (note instanceof Error) {
             this.#done = true;
+            this.#notes = null;
             return this._reject(note);
         }
 
@@ -55,7 +59,8 @@ exports.Team = class {
         }
 
         this.#done = true;
-        return this._resolve(this.#meetings === 1 ? this.#notes[0] : this.#notes);
+        this._resolve(this.#meetings === 1 ? this.#notes[0] : [...this.#notes]);
+        this.#notes = null;
     }
 
     async regroup(options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,11 @@ exports.Team = class {
         this._init(options);
     }
 
+    static _notes(instance) {
+
+        return instance.#notes;
+    }
+
     _init(options = {}) {
 
         this.work = new Promise((resolve, reject) => {

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,18 @@ describe('Team', () => {
 
         expect(count).to.equal('123');
     });
+
+    it('exposes private notes as a static accessor', async () => {
+
+        const team = new Teamwork.Team();
+
+        team.attend('1');
+
+        const internalNotes = Teamwork.Team._notes(team);
+        expect(internalNotes).to.equal(['1']);
+
+        await team.work;
+    });
 });
 
 describe('Events', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -146,14 +146,56 @@ describe('Team', () => {
 
     it('exposes private notes as a static accessor', async () => {
 
-        const team = new Teamwork.Team();
+        const team = new Teamwork.Team({ meetings: 2 });
 
         team.attend('1');
 
         const internalNotes = Teamwork.Team._notes(team);
         expect(internalNotes).to.equal(['1']);
 
+        team.attend('2');
+
         await team.work;
+    });
+
+    it('clears notes and doesn\'t add new notes when meeting is done', async () => {
+
+        const team = new Teamwork.Team({ meetings: 2 });
+
+        setTimeout(() => {
+
+            team.attend('1');
+        }, 100);
+
+        setTimeout(() => {
+
+            team.attend('2');
+        }, 150);
+
+        const notes = await team.work;
+        expect(notes).to.equal(['1', '2']);
+        expect(Teamwork.Team._notes(team)).to.be.null();
+
+        expect(() => team.attend('3')).to.not.throw();
+        expect(Teamwork.Team._notes(team)).to.be.null();
+    });
+
+    it('clears notes when attending with an error', async () => {
+
+        const team = new Teamwork.Team({ meetings: 2 });
+
+        setTimeout(() => {
+
+            team.attend('1');
+        }, 100);
+
+        setTimeout(() => {
+
+            team.attend(new Error());
+        }, 150);
+
+        await expect(team.work).to.reject();
+        expect(Teamwork.Team._notes(team)).to.be.null();
     });
 });
 


### PR DESCRIPTION
This should fix the memory leak. We empty the `notes` array once the meeting is done. We just need to shallow clone the array when sending it back through the resolved promise. That way we can read the array in userland while clearing the inner array to prevent infinite ref.

I wanted to add a regression test for this but since the `notes` array is private and as far as I know we cannot do referencing counting _natively_, I didn't find a good way to provide a test for it. Does anyone have an idea? @kanongil maybe you have a thought of how to test it?
