### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v6
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2015-2020, Sideway Inc, and project contributors  
+Copyright (c) 2015-2022, Project contributors
+Copyright (c) 2015-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
   ],
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "eslintConfig": {
     "extends": [
       "plugin:@hapi/module"
     ]
   },
-  "dependencies": {},
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "25.0.0-beta.1",
+    "@types/node": "^17.0.31",
+    "typescript": "^4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "25.0.0-beta.1",
+    "@hapi/lab": "^25.0.0",
     "@types/node": "^17.0.31",
     "typescript": "^4.6.4"
   },


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of code and lab, update typescript.

If this looks good, this will go out as teamwork v6.