### PR TITLE
Fix regroup() to work after team error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,10 @@ exports.Team = class {
 
     async regroup(options) {
 
-        await this.work;
+        try {
+            await this.work;
+        }
+        catch {}
 
         this._init(options);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -197,6 +197,17 @@ describe('Team', () => {
         await expect(team.work).to.reject();
         expect(Teamwork.Team._notes(team)).to.be.null();
     });
+
+    it('regroup works after team error', async () => {
+
+        const team = new Teamwork.Team({ meetings: 2, strict: true });
+        team.attend(new Error('failed'));
+
+        const regroup = team.regroup();
+
+        await expect(team.work).to.reject('failed');
+        await expect(regroup).to.not.reject();
+    });
 });
 
 describe('Events', () => {


### PR DESCRIPTION
This fixes the non-regroupable-on-error issue from https://github.com/hapijs/teamwork/issues/36#issuecomment-3199991171. 