### PR TITLE
Properly handle multiple iterators for Events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,8 +74,12 @@ exports.Team = class {
 
 exports.Events = class {
 
-    #pending = null;
-    #queue = [];
+    #iterators = new Set();
+
+    static _iterators(instance) {
+
+        return instance.#iterators;
+    }
 
     static isIterator(iterator) {
 
@@ -84,45 +88,40 @@ exports.Events = class {
 
     iterator() {
 
-        return new internals.EventsIterator(this);
+        const iterator = new internals.EventsIterator(this);
+
+        this.#iterators.add(iterator);
+
+        return iterator;
     }
 
     emit(value) {
 
-        this._queue({ value, done: false });
+        for (const iterator of this.#iterators) {
+            iterator._queue({ value, done: false });
+        }
     }
 
     end() {
 
-        this._queue({ done: true });
+        for (const iterator of this.#iterators) {
+            iterator._queue({ done: true });
+        }
     }
 
-    _next() {
+    _remove(iterator) {
 
-        if (this.#queue.length) {
-            return Promise.resolve(this.#queue.shift());
-        }
-
-        this.#pending = new exports.Team();
-        return this.#pending.work;
-    }
-
-    _queue(item) {
-
-        if (this.#pending) {
-            this.#pending.attend(item);
-            this.#pending = null;
-        }
-        else {
-            this.#queue.push(item);
-        }
+        this.#iterators.delete(iterator);
     }
 };
 
 
 internals.EventsIterator = class {
 
-    #events = null;
+    #events;
+
+    #pending = null;
+    #queue = [];
 
     constructor(events) {
 
@@ -136,6 +135,43 @@ internals.EventsIterator = class {
 
     next() {
 
-        return this.#events._next();
+        if (this.#queue.length) {
+            return Promise.resolve(this.#queue.shift());
+        }
+
+        if (!this.#events) {
+            return { done: true };
+        }
+
+        this.#pending = new exports.Team();
+        return this.#pending.work;
+    }
+
+    return() {
+
+        this._cleanup();
+
+        return { done: true };
+    }
+
+    _cleanup() {
+
+        this.#events?._remove(this);
+        this.#events = null;
+    }
+
+    _queue(item) {
+
+        if (item.done) {
+            this._cleanup();
+        }
+
+        if (this.#pending) {
+            this.#pending.attend(item);
+            this.#pending = null;
+        }
+        else {
+            this.#queue.push(item);
+        }
     }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -224,21 +224,156 @@ describe('Events', () => {
         events.end();
 
         expect(await collect).to.equal([1, 2, 3]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
     });
 
     it('iterates over events (queued)', async () => {
 
         const events = new Teamwork.Events();
+        const iterator = events.iterator();
+
         events.emit(1);
         events.emit(2);
         events.emit(3);
         events.end();
 
         const items = [];
-        for await (const item of events.iterator()) {
+        for await (const item of iterator) {
             items.push(item);
         }
 
         expect(items).to.equal([1, 2, 3]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
+    });
+
+    it('only iterates over new events after iterator() call', async () => {
+
+        const events = new Teamwork.Events();
+
+        events.emit(1);
+
+        const iterator = events.iterator();
+        events.emit(2);
+        events.emit(3);
+        events.end();
+
+        const items = [];
+        for await (const item of iterator) {
+            items.push(item);
+        }
+
+        expect(items).to.equal([2, 3]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
+    });
+
+    it('returns done for consumed iterators', async () => {
+
+        const events = new Teamwork.Events();
+        const iterator = events.iterator();
+
+        events.emit(1);
+        events.emit(2);
+        events.emit(3);
+        events.end();
+
+        const items = [];
+        for await (const item of iterator) {
+            items.push(item);
+        }
+
+        expect(iterator.next()).to.equal({ done: true });
+
+        expect(items).to.equal([1, 2, 3]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
+    });
+
+    it('can use break without leaking', async () => {
+
+        const events = new Teamwork.Events();
+        const iterator = events.iterator();
+
+        events.emit(1);
+        events.emit(2);
+
+        const items = [];
+        for await (const item of iterator) {
+            items.push(item);
+            break;
+        }
+
+        expect(items).to.equal([1]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
+    });
+
+    it('can throw without leaking', async () => {
+
+        const events = new Teamwork.Events();
+        const iterator = events.iterator();
+
+        events.emit(1);
+        events.emit(2);
+
+        const items = [];
+        await expect((async () => {
+
+            for await (const item of iterator) {
+                items.push(item);
+                throw new Error('fail');
+            }
+        })()).to.reject('fail');
+
+        expect(items).to.equal([1]);
+        expect(Teamwork.Events._iterators(events)).to.equal(new Set());
+    });
+
+    it('works with multiple iterators (serial)', async () => {
+
+        const events = new Teamwork.Events();
+        const iter1 = events.iterator();
+        const iter2 = events.iterator();
+
+        events.emit(1);
+        events.emit(2);
+        events.emit(3);
+        events.end();
+
+        const items1 = [];
+        for await (const item1 of iter1) {
+            items1.push(item1);
+        }
+
+        const items2 = [];
+        for await (const item2 of iter2) {
+            items2.push(item2);
+        }
+
+        expect(items1).to.equal([1, 2, 3]);
+        expect(items2).to.equal([1, 2, 3]);
+    });
+
+    it('works with multiple iterators (interleaved)', async () => {
+
+        const events = new Teamwork.Events();
+        const iter1 = events.iterator();
+        const iter2 = events.iterator();
+
+        events.emit(1);
+        events.emit(2);
+        events.emit(3);
+        events.end();
+
+        const items1 = [];
+        const items2 = [];
+        for await (const item1 of iter1) {
+            items1.push(item1);
+            if (items2.length === 0) {
+                for await (const item2 of iter2) {
+                    items2.push(item2);
+                }
+            }
+        }
+
+        expect(items1).to.equal([1, 2, 3]);
+        expect(items2).to.equal([1, 2, 3]);
     });
 });


### PR DESCRIPTION
Due to using shared state, the current implementation is broken if multiple iterators are used on the Events class.

This is fixed in this PR by:

1. Moving the state into the iterator itself.
2. Changing the semantics so that calling `iterator()` only returns newly emitted events, and not all emitted events during the Events instance lifetime.

Additionally, this fixes it so trying to iterate further on a completed iterator returns "done", instead of a never-ending Promise.

The updated semantics are required. Otherwise the Events instance will need to hang on to all emitted events, just in case someone calls `iterator()` on it again. Given that I am not aware of any existing usage of the Events feature, I cannot know if this will cause problems and should be considered a breaking change. It all depends on how early `iterator()` is called. An alternative fix, that might cause less breakage, is to add an assert that only allow `iterator()` to be called once.

Note that with the moved state, care must be taken not to cause a leak due to two-way references. I have added logic to handle this automatically when using `for-of` through the implicit `destroy()` call, as well as several tests.